### PR TITLE
Enable JWT in VcdApiClient

### DIFF
--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.0.2-alpha.4 (2021-06-10)
+- Enable JWT in VcdApiClient
+- Export vcd.transfer.client through the client index

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/angular-client",
-  "version": "0.0.2-alpha.3",
+  "version": "0.0.2-alpha.4",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2",

--- a/packages/angular/src/client/index.ts
+++ b/packages/angular/src/client/index.ts
@@ -1,6 +1,7 @@
 export * from './api.result.service';
 export * from './vcd.http.client';
 export * from './vcd.api.client';
+export * from './vcd.transfer.client';
 export * from './request.headers.interceptor';
 export * from './logging.interceptor';
 export * from './response.normalization.interceptor';

--- a/packages/angular/src/client/vcd.api.client.ts
+++ b/packages/angular/src/client/vcd.api.client.ts
@@ -132,7 +132,8 @@ export class VcdApiClient {
         );
 
         const tokenHolder: AuthTokenHolderService = this.injector.get(AuthTokenHolderService, { token: '' });
-        this._getSession = this.setAuthentication(tokenHolder.token)
+        const token = tokenHolder.jwt ? `Bearer ${tokenHolder.jwt}` : tokenHolder.token;
+        this._getSession = this.setAuthentication(token)
             .pipe(
                 publishReplay(1),
                 refCount()

--- a/packages/angular/src/container-hooks/index.ts
+++ b/packages/angular/src/container-hooks/index.ts
@@ -73,6 +73,12 @@ export interface AuthTokenHolderService {
      * The authentication token.
      */
     token: string;
+
+    /**
+     * JWT token
+     */
+    jwt?: string;
 }
 
-export const AuthTokenHolderService: {token: string} = containerHooks.AuthTokenHolderService;
+export const AuthTokenHolderService: AuthTokenHolderService = containerHooks.AuthTokenHolderService;
+


### PR DESCRIPTION
# Changes
- Enable JWT in VcdApiClient
   Up to now VcdApiClient was using `x-vcloud-authorization` which had been deprecated
    a few releases ago and is going to be completely removed from the VCD API.
    The one that should be used is the JWT and this commit enables this.
- Export vcd.transfer.client through the client index
- Bump @vcd/angular-client to 0.0.2-alpha.4

# Testing
- Use a VCD build in which `x-vcloud-authorization` usage has been removed
- Create a plugin that gets data from the backend using `VcdApiClient`
- Observe:
  -- If this code change is not applied - no data can be retrieved from the backend
  -- After applying this code change - the plugin can retrieve data from the backend
