### PR TITLE
Add cloud API authentication

### DIFF
--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [Unreleased]
+- Add cloud api authenticatication mechanism
 - Fix RequestHeadersInterceptor not to overwrite `Authorization` request header if it was already set
 
 # 0.0.2-alpha.4 (2021-06-10)

--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,4 +1,7 @@
 # [Unreleased]
+-
+
+# 0.0.2-alpha.5 (2021-06-23)
 - Add cloud api authenticatication mechanism
 - Fix RequestHeadersInterceptor not to overwrite `Authorization` request header if it was already set
 

--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [Unreleased]
+- Fix RequestHeadersInterceptor not to overwrite `Authorization` request header if it was already set
+
 # 0.0.2-alpha.4 (2021-06-10)
 - Enable JWT in VcdApiClient
 - Export vcd.transfer.client through the client index

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/angular-client",
-  "version": "0.0.2-alpha.4",
+  "version": "0.0.2-alpha.5",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2",

--- a/packages/angular/src/client/constants.ts
+++ b/packages/angular/src/client/constants.ts
@@ -1,0 +1,16 @@
+/**
+ * HTTP Headers
+ */
+export const HTTP_HEADERS = Object.freeze({
+
+    Authorization: 'Authorization',
+
+    etag: 'etag',
+
+    // Angular is dealing with case sensitive links despite the specification
+    // https://github.com/angular/angular/issues/6142
+    link: 'link',
+    Link: 'Link',
+
+    x_vcloud_authorization: 'x-vcloud-authorization'
+});

--- a/packages/angular/src/client/request.headers.interceptor.spec.ts
+++ b/packages/angular/src/client/request.headers.interceptor.spec.ts
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2021 VMware, Inc. All rights reserved. VMware Confidential
+ */
+import { HTTP_INTERCEPTORS, HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController, TestRequest } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { take } from 'rxjs/operators';
+import { parseHeaderHateoasLinks } from '.';
+import { HTTP_HEADERS } from './constants';
+import { RequestHeadersInterceptor } from './request.headers.interceptor';
+
+interface Test {
+    requestHeadersInterceptor: RequestHeadersInterceptor;
+    httpClient: HttpClient;
+    httpMock: HttpTestingController;
+}
+
+describe('RequestHeadersInterceptor', () => {
+    beforeEach(function(this: Test) {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                {
+                    provide: HTTP_INTERCEPTORS,
+                    useClass: RequestHeadersInterceptor,
+                    multi: true,
+                },
+            ],
+        });
+        this.httpClient = TestBed.get(HttpClient);
+        this.httpMock = TestBed.get(HttpTestingController);
+        this.requestHeadersInterceptor = TestBed.get(HTTP_INTERCEPTORS).find(int => int instanceof RequestHeadersInterceptor);
+    });
+    afterEach(function(this: Test) {
+        this.httpMock.verify();
+    });
+
+    describe('request headers', function(this: Test) {
+        describe('auth related', () => {
+            it('uses Authentication when authentication is bigger than 32 characters', function(this: Test) {
+                this.requestHeadersInterceptor.authentication = 'Bearer abcdefghijklmnopqrstuvwxyz_0123456789';
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe(null);
+            });
+            it('uses `x-vcloud-authorization` when authentication is less than 32 characters', function(this: Test) {
+                this.requestHeadersInterceptor.authentication = '0123456789';
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe(null);
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe('0123456789');
+            });
+            it('does not overwrite `Authorization` header if it was already set', function(this: Test) {
+                this.requestHeadersInterceptor.authentication = 'Bearer abcdefghijklmnopqrstuvwxyz_0123456789';
+                const headers = {[HTTP_HEADERS.Authorization]: 'Basic credentials'};
+                this.httpClient.get('endPoint', {headers}).pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe('Basic credentials');
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe(null);
+            });
+            it('does not set auth headers if authentication is not set', function(this: Test) {
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe(null);
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe(null);
+            });
+            it('does not set auth headers if authentication is set to null', function(this: Test) {
+                this.requestHeadersInterceptor.authentication = null;
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe(null);
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe(null);
+            });
+            it('does not set auth headers if authentication is set to empty string', function(this: Test) {
+                this.requestHeadersInterceptor.authentication = '';
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe();
+                const reqHeaders: HttpHeaders = this.httpMock.expectOne('endPoint').request.headers;
+                expect(reqHeaders.get(HTTP_HEADERS.Authorization)).toBe(null);
+                expect(reqHeaders.get(HTTP_HEADERS.x_vcloud_authorization)).toBe(null);
+            });
+        });
+    });
+
+    describe('handling response', () => {
+
+        // Angular is dealing with case sensitive links despite the specification https://github.com/angular/angular/issues/6142
+        describe('related to `link` response headers', () => {
+            it('adds `link` body property built from the `link` response header', function(this: Test) {
+                const body = { someValue: 'test'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.link]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith(body);
+            });
+            it('adds `link` body property built from the `link` response header even for arrays', function(this: Test) {
+                const body = [1, 2, 3];
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.link]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                const response = [...body];
+                // Yeh, link property is attached even for arrays
+                (response as any).link = parseHeaderHateoasLinks(headers[HTTP_HEADERS.link]);
+                expect(subscriptionSpy).toHaveBeenCalledWith(response);
+            });
+            it('overwrites the original `link` body property if such exists', function(this: Test) {
+                const body = { someValue: 'test', link: 'some link property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = new HttpHeaders({
+                    [HTTP_HEADERS.link]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                });
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                    link: parseHeaderHateoasLinks(headers.get(HTTP_HEADERS.link)),
+                });
+            });
+            it('does not modify the original `link` body property if there are no `link` response headers', function(this: Test) {
+                const body = { someValue: 'test', link: 'some link property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith(body);
+            });
+        });
+        describe('related to `Link` response headers', () => {
+            it('adds `link` body property built from the `Link` response header', function(this: Test) {
+                const body = { someValue: 'test'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.Link]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                    link: parseHeaderHateoasLinks(headers[HTTP_HEADERS.Link])
+                });
+            });
+            it('adds `link` body property built from the `Link` response header even for arrays', function(this: Test) {
+                const body = [1, 2, 3];
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.Link]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                const response = [...body];
+                // Yeh, link property is attached even for arrays
+                (response as any).link = parseHeaderHateoasLinks(headers[HTTP_HEADERS.Link]);
+                expect(subscriptionSpy).toHaveBeenCalledWith(response);
+            });
+            it('overwrites the original `link` body property if such exists', function(this: Test) {
+                const body = { someValue: 'test', link: 'some link property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = new HttpHeaders({
+                    Link: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                });
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                    link: parseHeaderHateoasLinks(headers.get(HTTP_HEADERS.Link)),
+                });
+            });
+            it('does not modify the original `link` body property if there are no `Link` response headers', function(this: Test) {
+                const body = { someValue: 'test', link: 'some link property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith(body);
+            });
+        });
+        describe('related to `etag` response headers', () => {
+            it('adds `etag` body property built from the `etag` response header', function(this: Test) {
+                const body = { someValue: 'test'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.etag]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                    etag: parseHeaderHateoasLinks(headers[HTTP_HEADERS.etag])
+                });
+            });
+            it('adds `etag` body property built from the `etag` response header even for arrays', function(this: Test) {
+                const body = [1, 2, 3];
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.etag]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                const response = [...body];
+                // Yeh, link property is attached even for arrays
+                (response as any).etag = parseHeaderHateoasLinks(headers[HTTP_HEADERS.etag]);
+                expect(subscriptionSpy).toHaveBeenCalledWith(response);
+            });
+            it('overwrites the original `etag` body property if such exists', function(this: Test) {
+                const body = { someValue: 'test', etag: 'some etag property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                    [HTTP_HEADERS.etag]: '<url1>;rel="down";type="application/json";model="model1";title="id1",<url2>',
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                    etag: parseHeaderHateoasLinks(headers[HTTP_HEADERS.etag]),
+                });
+            });
+            it('does not modify the original `etag` body property if there are no `etag` response headers', function(this: Test) {
+                const body = { someValue: 'test', etag: 'some etag property'};
+                const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+                const headers = {
+                };
+
+                this.httpClient.get('endPoint').pipe(take(1)).subscribe(subscriptionSpy);
+                this.httpMock.expectOne('endPoint').flush(body, {headers});
+
+                expect(subscriptionSpy).toHaveBeenCalledWith({
+                    ...body,
+                });
+            });
+        });
+    });
+
+
+});

--- a/packages/angular/src/client/request.headers.interceptor.ts
+++ b/packages/angular/src/client/request.headers.interceptor.ts
@@ -3,6 +3,7 @@ import { HttpHandler, HttpInterceptor, HttpRequest, HttpEvent, HttpHeaders, Http
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { parseHeaderHateoasLinks } from '.';
+import { HTTP_HEADERS } from './constants';
 
 // tslint:disable:variable-name
 @Injectable()
@@ -25,11 +26,12 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
         this._version = _version;
     }
 
-    private _authenticationHeader = 'Authorization';
+    private _authenticationHeader = HTTP_HEADERS.Authorization;
     private _authentication: string;
     set authentication(_authentication: string) {
         this._authentication = _authentication;
-        this._authenticationHeader = (this._authentication.length > 32) ? 'Authorization' : 'x-vcloud-authorization';
+        this._authenticationHeader = (this._authentication && this._authentication.length > 32) ?
+            HTTP_HEADERS.Authorization : HTTP_HEADERS.x_vcloud_authorization;
     }
 
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -43,7 +45,7 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
             headers = this.setContentTypeHeader(headers, req.url);
         }
 
-        if (this._authentication) {
+        if (this._authentication && !headers.has(HTTP_HEADERS.Authorization)) {
             headers = headers.set(this._authenticationHeader, this._authentication);
         }
 
@@ -62,16 +64,16 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
                         return res;
                     }
 
-                    if (res.headers.has('link')) {
-                        res.body.link = parseHeaderHateoasLinks(res.headers.get('link'));
+                    if (res.headers.has(HTTP_HEADERS.link)) {
+                        res.body.link = parseHeaderHateoasLinks(res.headers.get(HTTP_HEADERS.link));
                     }
 
-                    if (res.headers.has('Link')) {
-                        res.body.link = parseHeaderHateoasLinks(res.headers.get('Link'));
+                    if (res.headers.has(HTTP_HEADERS.Link)) {
+                        res.body.link = parseHeaderHateoasLinks(res.headers.get(HTTP_HEADERS.Link));
                     }
 
-                    if (res.headers.has('etag')) {
-                        res.body.etag = res.headers.get('etag');
+                    if (res.headers.has(HTTP_HEADERS.etag)) {
+                        res.body.etag = parseHeaderHateoasLinks(res.headers.get(HTTP_HEADERS.etag));
                     }
                 }
                 return res;

--- a/packages/angular/src/client/vcd.api.client.spec.data.ts
+++ b/packages/angular/src/client/vcd.api.client.spec.data.ts
@@ -1,0 +1,48 @@
+import { AccessibleLocations, Session } from 'src/openapi';
+
+export const CLOUDAPI_SESSION: Session = Object.freeze({
+    id: 'cloudapi_session_id',
+    user: { name: 'cloudapi_user', id: 'cloudapi_user_id'},
+    org: { name: 'cloudapi_org', id: 'cloudapi_org_id'},
+    location: 'cloudapi_session_location',
+    roles: [],
+    roleRefs: [],
+    sessionIdleTimeoutMinutes: 123456789
+});
+
+export const ACCESSIBLE_LOCATIONS: AccessibleLocations = Object.freeze({
+    resultTotal: 2,
+    pageCount: 1,
+    page: 1,
+    pageSize: 2,
+    values: [
+        {
+            locationId: `${CLOUDAPI_SESSION.location}`,
+            site: {
+                name: 'cassini',
+                id: 'urn:vcloud:site:4f569ca4-2a1f-457c-b587-21339358a38a'
+            },
+            org: {
+                name: 'System',
+                id: 'urn:vcloud:org:a93c9db9-7471-3192-8d09-a8f7eeda85f9'
+            },
+            restApiEndpoint: 'https://cassini.eng.vmware.com',
+            uiEndpoint: 'https://cassini.eng.vmware.com',
+            apiVersion: '36.0'
+        },
+        {
+            locationId: 'a93c9db9-7471-3192-8d09-a8f7eeda85f9@92bed505-c2ac-4e76-892b-105dbe47b6bb',
+            site: {
+                name: 'juno',
+                id: 'urn:vcloud:site:92bed505-c2ac-4e76-892b-105dbe47b6bb'
+            },
+            org: {
+                name: 'System',
+                id: 'urn:vcloud:org:a93c9db9-7471-3192-8d09-a8f7eeda85f9'
+            },
+            restApiEndpoint: 'https://juno.eng.vmware.com',
+            uiEndpoint: 'https://juno.eng.vmware.com',
+            apiVersion: '36.0'
+        }
+    ]
+});

--- a/packages/angular/src/client/vcd.api.client.spec.ts
+++ b/packages/angular/src/client/vcd.api.client.spec.ts
@@ -12,6 +12,10 @@ import { ResponseNormalizationInterceptor } from './response.normalization.inter
 import {HttpHeaders, HttpRequest} from '@angular/common/http';
 import { ReflectiveInjector } from '@angular/core';
 import { concatMap, take } from 'rxjs/operators';
+import { Session } from '../openapi';
+import { HTTP_HEADERS } from './constants';
+import { ACCESSIBLE_LOCATIONS, CLOUDAPI_SESSION } from './vcd.api.client.spec.data';
+import { Subscription } from 'rxjs';
 
 // verifies that the GET api/versions endpoint is called exactly once, and returns the provided response
 function handleVersionNegotiation(versionResponse: SupportedVersionsType, httpMock: HttpTestingController): void {
@@ -27,6 +31,18 @@ function handleSessionLoad(httpMock: HttpTestingController, provider: boolean = 
     const session = {} as SessionType;
     if (provider) {
         session.org = 'System';
+    }
+
+    req[0].flush(session);
+}
+
+// verifies that the GET api/session endpoint is called exactly once, and returns a mock SessionType response
+function handleCloudApiSessionLoad(httpMock: HttpTestingController, provider: boolean = false): void {
+    const req: TestRequest[] = httpMock.match('rootUrl/cloudapi/1.0.0/sessions/current');
+    expect(req.length).toBe(1);
+    const session = {} as Session;
+    if (provider) {
+        session.org = {name: 'System', id: 'system_session_id'};
     }
 
     req[0].flush(session);
@@ -67,13 +83,15 @@ describe('API client pre-request validation', () => {
         httpMock.verify();
     });
 
-    describe('authentication', () => {
+    describe('authentication headers', () => {
 
         it('uses `x-vcloud-authorization` header if jwt is not provided', () => {
             apiClient.setVersion('30.0');
             apiClient.get('api/test').pipe(take(1)).subscribe(() => {
             });
             handleSessionLoad(httpMock);
+            // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+            handleCloudApiSessionLoad(httpMock);
             const req: TestRequest = httpMock.expectOne('rootUrl/api/test');
             expect(req.request.headers.get('x-vcloud-authorization')).toBe('authToken');
         });
@@ -88,6 +106,8 @@ describe('API client pre-request validation', () => {
             apiClient.get('api/test').pipe(take(1)).subscribe(() => {
             });
             handleSessionLoad(httpMock);
+            // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+            handleCloudApiSessionLoad(httpMock);
             const req: TestRequest = httpMock.expectOne('rootUrl/api/test');
             expect(req.request.headers.get('x-vcloud-authorization')).toEqual(null);
             expect(req.request.headers.get('Authorization')).toBe(`Bearer JWT_TOKEN_which_is_longer_than_32`);
@@ -105,6 +125,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test');
     });
 
@@ -119,6 +142,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test');
     });
 
@@ -151,6 +177,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         expect(httpMock.match('rootUrl/api/test').length).toBe(2);
     });
 
@@ -162,7 +191,27 @@ describe('API client pre-request validation', () => {
 
         httpMock.expectNone('rootUrl/api/versions');
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test');
+    });
+
+    it('performs two session calls to the backend one for the deprecated `api` endpoint and one to the `cloudapi`', () => {
+        const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+        apiClient.setVersion('30.0');
+        apiClient.get('api/test').subscribe(subscriptionSpy);
+
+        // There is no api call since there are two pending observables
+        httpMock.expectNone('rootUrl/api/test');
+
+        // Resolve the observables
+        httpMock.expectOne('rootUrl/api/session').flush({});
+        httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush({});
+
+        // Now there is an api request
+        httpMock.expectOne('rootUrl/api/test').flush({});
+        expect(subscriptionSpy).toHaveBeenCalledTimes(1);
     });
 
     it('performs validation chain on createAsync', () => {
@@ -177,6 +226,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(MOCK_TASK);
     });
 
@@ -193,6 +245,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(entity);
     });
 
@@ -208,6 +263,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(MOCK_TASK);
     });
 
@@ -222,6 +280,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test');
     });
 
@@ -237,6 +298,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(MOCK_TASK);
     });
 
@@ -254,6 +318,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(MOCK_TASK);
     });
 
@@ -270,6 +337,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(entity);
     });
 
@@ -288,6 +358,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/test').flush(entity);
     });
 
@@ -304,6 +377,9 @@ describe('API client pre-request validation', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock);
+
         httpMock.expectOne('rootUrl/api/query?type=test&format=idrecords&links=true&pageSize=25').flush(mockResult);
     });
 });
@@ -350,6 +426,9 @@ describe('Provider in tenant scope actAs scoping', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock, true);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock, true);
+
         httpMock.expectOne((request: HttpRequest<any>) => {
             return request.url === 'rootUrl/api/query?type=test&format=idrecords&links=true&pageSize=25'
               && request.headers.get('X-VMWARE-VCLOUD-TENANT-CONTEXT') === 'a1b2c3d4e5f6';
@@ -371,6 +450,8 @@ describe('Provider in tenant scope actAs scoping', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock, true);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock, true);
 
         httpMock.expectOne((request: HttpRequest<any>) => {
             return request.url === 'rootUrl/api/query?type=test&format=idrecords&links=true&pageSize=25'
@@ -421,6 +502,9 @@ describe('Provider in provider scope actAs scoping', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock, true);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock, true);
+
         httpMock.expectOne((request: HttpRequest<any>) => {
             return request.url === 'rootUrl/api/query?type=test&format=idrecords&links=true&pageSize=25'
               && !request.headers.has('X-VMWARE-VCLOUD-TENANT-CONTEXT');
@@ -442,6 +526,9 @@ describe('Provider in provider scope actAs scoping', () => {
 
         handleVersionNegotiation(supportedVersions, httpMock);
         handleSessionLoad(httpMock, true);
+        // Introducing `cloudapi`, deprecating the old `api` endpoint requires two calls to the backend (until the old `api` is removed)
+        handleCloudApiSessionLoad(httpMock, true);
+
         httpMock.expectOne((request: HttpRequest<any>) => {
             return request.url === 'rootUrl/api/query?type=test&format=idrecords&links=true&pageSize=25'
               && request.headers.get('X-VMWARE-VCLOUD-TENANT-CONTEXT') === 'f6e5d4c3b2a1';
@@ -517,5 +604,365 @@ describe('API client utility code', () => {
             expect(apiClient.canPerformAction(item, LinkRelType.remove)).toBeFalsy();
         });
     });
+});
+
+describe('cloudapi', () => {
+    let httpClient: VcdHttpClient;
+    let httpMock: HttpTestingController;
+    let apiClient: VcdApiClient;
+    const subs: Subscription[] = [];
+    const subscriptionSpy = jasmine.createSpy('subscriptionSpy');
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                HttpClientTestingModule
+            ],
+            providers: [
+                LoggingInterceptor,
+                RequestHeadersInterceptor,
+                ResponseNormalizationInterceptor,
+                VcdHttpClient
+            ]
+        });
+
+        httpClient = TestBed.get(VcdHttpClient);
+        httpMock = TestBed.get(HttpTestingController);
+        const injector = ReflectiveInjector.resolveAndCreate([VcdHttpClient,
+            {provide: AuthTokenHolderService, useValue: { token: 'authToken', jwt: 'JWT_TOKEN_which_is_longer_than_32' }},
+            {provide: API_ROOT_URL, useValue: 'rootUrl'},
+            {provide: SESSION_ORG_ID, useValue: 'a1b2c3d4e5f6'}]);
+        apiClient = new VcdApiClient(httpClient, injector);
+        // Version doesn't matter in fact we set it in order the testing code to be simpler
+        apiClient.setVersion('30.0');
+    }));
+
+    afterEach(() => {
+        httpMock.verify();
+        subscriptionSpy.calls.reset();
+        subs.forEach(s => s.unsubscribe());
+        subs.length = 0;
+    });
+
+    function performCloudApiLogin(onSuccess = (s?) => {}, onError = () => {}) {
+        const headers = {
+            ['x-vmware-vcloud-token-type']: ['Bearer'],
+            ['x-vmware-vcloud-access-token']: 'abcdefghijklmnopqrstuvwxyz_0123456789',
+            // Link headers become part of the body {@link RequestHeadersInterceptor#intercept}
+            [HTTP_HEADERS.Link]: '<accessibleLocations>;rel="down";type="application/json";model="AccessibleLocations"',
+        };
+
+        apiClient.cloudApiLogin('user', 'Org1', 'pass').pipe(take(1)).subscribe(onSuccess, onError);
+        httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions').flush({...CLOUDAPI_SESSION}, {headers});
+    }
+
+    function performAuthFailure(operation: string, onSuccess = () => {}, onError = () => {}) {
+        if (operation === 'cloudApiLogin') {
+            apiClient.cloudApiLogin('user', 'Org1', 'pass').pipe(take(1)).subscribe(onSuccess, onError);
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions').error(null);
+        } else if (operation === 'setCloudApiAuthentication') {
+            apiClient.setCloudApiAuthentication('any').pipe(take(1)).subscribe(onSuccess, onError);
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').error(null);
+        } else {
+            throw new Error('Unsuported operation');
+        }
+    }
+
+    function sharedAuthenticationFailures(operation: string) {
+
+        describe('on error', () => {
+
+            it('throws an error', () => {
+                const onSuccess = jasmine.createSpy('onSuccess');
+                const onError = jasmine.createSpy('onError');
+                performAuthFailure(operation, onSuccess, onError);
+                expect(onSuccess).not.toHaveBeenCalled();
+                expect(onError).toHaveBeenCalled();
+            });
+
+            describe('when there was a valid session before', () => {
+
+                beforeEach(() => {
+                    performCloudApiLogin();
+                });
+
+                it('emits null session', () => {
+                    subs.push(apiClient.cloudApiSession.subscribe(subscriptionSpy));
+                    expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.objectContaining(CLOUDAPI_SESSION));
+                    performAuthFailure(operation);
+                    expect(subscriptionSpy).toHaveBeenCalledWith(null);
+                    expect(subscriptionSpy).toHaveBeenCalledTimes(2);
+                });
+
+                it('does not set Authentication header for any subsequent calls', () => {
+                    performAuthFailure(operation);
+                    subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+                    const req: TestRequest = httpMock.expectOne('rootUrl/endPoint');
+                    expect(req.request.headers.get(HTTP_HEADERS.Authorization)).toBe(null);
+                    expect(subscriptionSpy).not.toHaveBeenCalled();
+                });
+            });
+
+        });
+
+    }
+
+    describe('accessing the old `api` endpoint', () => {
+        it('does not exist after `cloudApiLogin()` call', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+            httpMock.expectNone((request: HttpRequest<any>) => request.url.includes('/api'));
+            httpMock.expectOne('rootUrl/endPoint');
+            expect(subscriptionSpy).not.toHaveBeenCalled();
+        });
+        it('exists if no explicit cloud api authentication is done', () => {
+            subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+            httpMock.expectNone('rootUrl/endPoint');
+            httpMock.expectOne('rootUrl/api/session').flush({});
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush({});
+            httpMock.expectOne('rootUrl/endPoint').flush({});
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+        it('is not affected if cloudapi/1.0.0/sessions/current fails', () => {
+            subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+            httpMock.expectOne('rootUrl/api/session').flush({});
+            // httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush({});
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').error(null);
+            httpMock.expectOne('rootUrl/endPoint').flush({});
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+        describe('after cloud api authentication', () => {
+            beforeEach(() => performCloudApiLogin());
+            it('throws an error when calling `login` to the old /api endpoint', () => {
+                const errorSubscriptionSpy = jasmine.createSpy('errorSubscriptionSpy');
+                subs.push(apiClient.login('user', 'Org1', 'pass').subscribe(subscriptionSpy, errorSubscriptionSpy));
+                expect(subscriptionSpy).not.toHaveBeenCalled();
+                expect(errorSubscriptionSpy).toHaveBeenCalled();
+            });
+            it('throws an error when calling `setAuthentication` to the old /api endpoint', () => {
+                const errorSubscriptionSpy = jasmine.createSpy('errorSubscriptionSpy');
+                subs.push(apiClient.setAuthentication('any').subscribe(subscriptionSpy, errorSubscriptionSpy));
+                expect(subscriptionSpy).not.toHaveBeenCalled();
+                expect(errorSubscriptionSpy).toHaveBeenCalled();
+            });
+
+        });
+    });
+
+    describe('cloudApiLogin', () => {
+
+        it('performs a call to a provider endpoint when login as System', () => {
+            subs.push(apiClient.cloudApiLogin('user', 'System', 'pass').subscribe(subscriptionSpy));
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/provider').flush({});
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('performs a call to a tenant endpoint when login as tenant', () => {
+            subs.push(apiClient.cloudApiLogin('user', 'Org1', 'pass').subscribe(subscriptionSpy));
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions').flush({});
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('uses `Basic` authentication header', () => {
+            subs.push(apiClient.cloudApiLogin('user', 'Org1', 'pass').subscribe(subscriptionSpy));
+            const req: TestRequest = httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions');
+            req.flush({});
+            expect(req.request.headers.get(HTTP_HEADERS.Authorization)).toBe(`Basic ${btoa('user@Org1:pass')}`);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        describe('on success', () => {
+
+            it('returns a session', () => {
+                performCloudApiLogin(subscriptionSpy);
+                expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.objectContaining(CLOUDAPI_SESSION));
+            });
+
+            describe('subsequent requests', () => {
+
+                beforeEach(() => {
+                    performCloudApiLogin();
+                });
+
+                it('reuse the authentication from the login response', () => {
+                    subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+                    const req: TestRequest = httpMock.expectOne('rootUrl/endPoint');
+                    req.flush({});
+                    expect(req.request.headers.get(HTTP_HEADERS.Authorization)).toBe('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+                    expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+                });
+
+                it('do not produce a call to the old `api` endpoint', () => {
+                    subs.push(apiClient.get('endPoint').subscribe(subscriptionSpy));
+                    httpMock.expectNone((request: HttpRequest<any>) => request.url.includes('/api'));
+                    httpMock.expectOne('rootUrl/endPoint').flush({});
+                    expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+                });
+
+            });
+        });
+
+        sharedAuthenticationFailures('cloudApiLogin');
+
+    });
+
+    describe('setCloudApiAuthentication', () => {
+
+        it('does not sets the Authorization header if there is no subscription to the observable', () => {
+            apiClient.setCloudApiAuthentication('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+            httpMock.expectNone('rootUrl/cloudapi/1.0.0/sessions/current');
+            subs.push(apiClient.get('endPoint').subscribe());
+            const req: TestRequest = httpMock.expectOne('rootUrl/endPoint');
+            expect(req.request.headers.get(HTTP_HEADERS.Authorization)).not.toBe('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+        });
+
+        it('sets the Authorization header for the current session request', () => {
+            subs.push(apiClient.setCloudApiAuthentication('Bearer abcdefghijklmnopqrstuvwxyz_0123456789').subscribe());
+            const req: TestRequest = httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current');
+            expect(req.request.headers.get(HTTP_HEADERS.Authorization)).toBe('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+        });
+
+        it('sets the Authorization header for the subsequent requests', () => {
+            subs.push(apiClient.setCloudApiAuthentication('Bearer abcdefghijklmnopqrstuvwxyz_0123456789').subscribe());
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current');
+            subs.push(apiClient.get('endPoint').subscribe());
+            const req: TestRequest = httpMock.expectOne('rootUrl/endPoint');
+            expect(req.request.headers.get(HTTP_HEADERS.Authorization)).toBe('Bearer abcdefghijklmnopqrstuvwxyz_0123456789');
+        });
+
+        it('returns a session', () => {
+            subs.push(apiClient.setCloudApiAuthentication('any').subscribe(subscriptionSpy));
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush(CLOUDAPI_SESSION);
+            expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.objectContaining(CLOUDAPI_SESSION));
+        });
+
+        sharedAuthenticationFailures('setCloudApiAuthentication');
+
+    });
+
+    describe('cloudApiSession', () => {
+
+        it('is emitted after `cloudApiLogin()` call', () => {
+            performCloudApiLogin();
+            apiClient.cloudApiSession.subscribe(subscriptionSpy);
+            expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.objectContaining(CLOUDAPI_SESSION));
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('is emitted after `setCloudApiAuthentication()` call', () => {
+            subs.push(apiClient.setCloudApiAuthentication('any').subscribe());
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush(CLOUDAPI_SESSION);
+            apiClient.cloudApiSession.subscribe(subscriptionSpy);
+            expect(subscriptionSpy).toHaveBeenCalledWith(jasmine.objectContaining(CLOUDAPI_SESSION));
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+    });
+
+    describe('username', () => {
+
+        it('is emitted after `cloudApiLogin()` call', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.username.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.user.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('is emitted after `setCloudApiAuthentication()` call', () => {
+            subs.push(apiClient.setCloudApiAuthentication('any').subscribe());
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush(CLOUDAPI_SESSION);
+            subs.push(apiClient.username.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.user.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('is null after `cloudApiLogin()` failure', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.username.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.user.name);
+            performAuthFailure('cloudApiLogin');
+            expect(subscriptionSpy).toHaveBeenCalledWith(null);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('can be subscribed to in advance', () => {
+            // Intentionally subscribe in advance
+            subs.push(apiClient.username.subscribe(subscriptionSpy));
+
+            // Since we are subscribing prior to explicit cloudapi request there are 2 pending requests
+            // originating from the constructor
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush({});
+            httpMock.expectOne('rootUrl/api/session').flush({user: 'user_name'});
+            expect(subscriptionSpy).toHaveBeenCalledWith('user_name');
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+            subscriptionSpy.calls.reset();
+
+            // Provide the request from the constructor
+            performCloudApiLogin();
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.user.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+    });
+
+    describe('organization', () => {
+
+        it('is emitted after `cloudApiLogin()` call', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.organization.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.org.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('is emitted after `setCloudApiAuthentication()` call', () => {
+            subs.push(apiClient.setCloudApiAuthentication('any').subscribe());
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush(CLOUDAPI_SESSION);
+            subs.push(apiClient.organization.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.org.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('is null after `cloudApiLogin()` failure', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.organization.subscribe(subscriptionSpy));
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.org.name);
+            performAuthFailure('cloudApiLogin');
+            expect(subscriptionSpy).toHaveBeenCalledWith(null);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('can be subscribed to in advance', () => {
+            // Intentionally subscribe in advance
+            subs.push(apiClient.organization.subscribe(subscriptionSpy));
+
+            // Since we are subscribing prior to explicit cloudapi request there are 2 pending requests
+            // originating from the constructor
+            httpMock.expectOne('rootUrl/cloudapi/1.0.0/sessions/current').flush({});
+            httpMock.expectOne('rootUrl/api/session').flush({org: 'org_name'});
+            expect(subscriptionSpy).toHaveBeenCalledWith('org_name');
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+            subscriptionSpy.calls.reset();
+
+            // Provide the request from the constructor
+            performCloudApiLogin();
+            expect(subscriptionSpy).toHaveBeenCalledWith(CLOUDAPI_SESSION.org.name);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+    });
+
+    describe('cloudApiLocation', () => {
+
+        it('is emitted after `cloudApiLogin()` call', () => {
+            performCloudApiLogin();
+            subs.push(apiClient.cloudApiLocation.subscribe(subscriptionSpy));
+            // There is a request to the backend to get the accessibleLocations
+            httpMock.expectOne('accessibleLocations').flush(ACCESSIBLE_LOCATIONS);
+            expect(subscriptionSpy).toHaveBeenCalledWith(ACCESSIBLE_LOCATIONS.values[0]);
+            expect(subscriptionSpy).toHaveBeenCalledTimes(1);
+        });
+
+    });
+
 });
 

--- a/packages/angular/src/client/vcd.api.client.ts
+++ b/packages/angular/src/client/vcd.api.client.ts
@@ -1,9 +1,7 @@
 import { Injectable, Injector } from '@angular/core';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
-
-import { Observable, BehaviorSubject, of } from 'rxjs';
-import { tap, map, concatMap, publishReplay, refCount, skipWhile } from 'rxjs/operators';
-
+import { Observable, BehaviorSubject, of, throwError, merge } from 'rxjs';
+import { catchError, tap, map, concatMap, publishReplay, refCount, skipWhile, switchMap, withLatestFrom } from 'rxjs/operators';
 import { SessionType,
     AuthorizedLocationType,
     ResourceType, LinkType,
@@ -12,10 +10,14 @@ import { SessionType,
     TaskType
 } from '@vcd/bindings/vcloud/api/rest/schema_v1_5';
 import { SupportedVersionsType } from '@vcd/bindings/vcloud/api/rest/schema/versioning';
+import { AccessibleLocation, AccessibleLocations, Session } from '../openapi';
 import { Query } from '../query/index';
 import { AuthTokenHolderService, API_ROOT_URL, SESSION_SCOPE, SESSION_ORG_ID } from '../container-hooks';
 import { VcdHttpClient } from './vcd.http.client';
 import { VcdTransferClient } from './vcd.transfer.client';
+import { HTTP_HEADERS } from './constants';
+import { filter } from 'rxjs/operators';
+import { mapTo } from 'rxjs/operators';
 
 export const TRANSFER_LINK_REL = 'upload:default';
 export type Navigable = ResourceType | { link?: LinkType[] };
@@ -95,7 +97,24 @@ export enum LinkRelType {
 }
 
 /**
- * A basic client for interacting with the vCloud Director APIs.
+ * A basic client for interacting with the VMware Cloud Director APIs.
+ *
+ * A VMware Cloud Director plugin can get a reference to this client by using angular injection.
+ * ```
+ *     constructor(private vcdApi: VcdApiClient) {}
+ * ```
+ *
+ * VcdApiClient reuses the authentication from the VCD platform so in general there is
+ * no need of an explicit authentication/login.
+ *
+ * When dealing with the session management there are two APIs:
+ * 1. Deprecated legacy API that is using the `api/session` endpoint and the corresponding models
+ * 2. Newly added API that is using the `cloudapi` endpoint and the corresponding models
+ *
+ * Note that if a plugin performs an explicit cloud api authentication call through
+ * {@link VcdApiClient#setCloudApiAuthentication} or {@link VcdApiClient#cloudApiLogin}
+ * from that moment on the VcdApiClient uses only cloud api session management.
+ * This means calls to {@link VcdApiClient#setAuthentication} or {@link VcdApiClient#login} have no effect.
  */
 @Injectable()
 export class VcdApiClient {
@@ -110,14 +129,49 @@ export class VcdApiClient {
         return this.http.requestHeadersInterceptor.version;
     }
 
+    private _negotiateVersion: Observable<string>;
+    private _baseUrl: string;
+
+    /**
+     * @deprecated Use {@link VcdApiClient#_cloudApiSession}
+     */
     private _session: BehaviorSubject<SessionType> = new BehaviorSubject<SessionType>(null);
     private _sessionObservable: Observable<SessionType> = this._session.asObservable()
         .pipe(
             skipWhile(session => !session)
         );
-    private _negotiateVersion: Observable<string>;
     private _getSession: Observable<SessionType>;
-    private _baseUrl: string;
+
+    /**
+     * CloudApi Session
+     */
+    private _cloudApiSession: BehaviorSubject<Session> = new BehaviorSubject<Session>(null);
+    private _cloudApiSessionObservable: Observable<Session> = this._cloudApiSession.asObservable()
+        .pipe(
+            skipWhile(session => !session)
+        );
+    /**
+     * This observable has a special purpose when doing automatic login during the constructor initialization.
+     * It allows backend call only after an API version is set.
+     * It also ensures that a backend call to get the current session is done once prior to any other calls.
+     *
+     * In case of an explicit cloud api auth request there is no need of this observable
+     * since this auth request will retrieve the session itself
+     */
+    private _getCloudApiSession: Observable<Session>;
+
+    private _cloudApiSessionLinks: BehaviorSubject<LinkType[]> = new BehaviorSubject<LinkType[]>([]);
+
+    /**
+     * Cached, lazy loaded observable of the AccessibleLocation array
+     */
+    private _cloudApiAccessibleLocations: Observable<AccessibleLocation[]>;
+
+    /**
+     * This property determines if it is an explicit cloud api login.
+     * In this case the old API (/api/session) should not be used at all.
+     */
+    private _isCloudApiLogin = false;
 
     constructor(private http: VcdHttpClient,
                 private injector: Injector) {
@@ -138,6 +192,14 @@ export class VcdApiClient {
                 publishReplay(1),
                 refCount()
             );
+
+        this._getCloudApiSession = this.setCloudApiAuthentication(token)
+            .pipe(
+                publishReplay(1),
+                refCount()
+            );
+        // This is not an explicit cloud api login
+        this._isCloudApiLogin = false;
     }
 
     private negotiateVersion(serverVersions: SupportedVersionsType): string {
@@ -145,17 +207,44 @@ export class VcdApiClient {
         const negotiatedVersions: string[] = VcdApiClient.CANDIDATE_VERSIONS.filter(cv => supportedVersions.some(sv => cv === sv));
 
         if (negotiatedVersions.length === 0) {
-            throw new Error(`The vCloud Director server does not support any API versions
+            throw new Error(`The VMware Cloud Director server does not support any API versions
                 used by this API client. Client candidate versions: ${VcdApiClient.CANDIDATE_VERSIONS};
-                vCloud Director supported versions: ${supportedVersions}`);
+                VMware Cloud Director supported versions: ${supportedVersions}`);
         }
 
         return negotiatedVersions[0];
     }
 
-    private validateRequestContext(): Observable<SessionType> {
+    /**
+     * The purpose of this function is to ensure that prior to sending any call to the backend
+     * the version has been set and the current session has been retrieved.
+     * Note that this is important during the automatic authentication that is done during the
+     * constructor initialization, when the plugin is not required to perform its own explicit authentication
+     * but rather the ones from the underlying framework is used.
+     */
+    private validateRequestContext(): Observable<true> {
+        return (this.version ? of(this.version) : this._negotiateVersion)
+            .pipe(
+                // In case of a cloud api login we are not interested in the /api/session session
+                concatMap(() => this._isCloudApiLogin ? of(null) : this._getSession),
+                concatMap(() => this._getCloudApiSession
+                    // In case of cloud api failure we do not want to prevent further execution
+                    // for backward compatibility considerations since this may be a case
+                    // when cloud api is not supported at all for the specified version
+                    .pipe(catchError((e) => of(true)))
+                ),
+                mapTo(true)
+            );
+        }
+
+    /**
+     *
+     * For use cases wich solely depends on cloudapi without any backward compatibility
+     * there should be no dependence on the old /api endpoint at all
+     */
+    private validateRequestContextCloudApiOnly(): Observable<Session> {
         return (this.version ? of(this.version) : this._negotiateVersion).pipe(
-            concatMap(() => this._getSession)
+            concatMap(() => this._getCloudApiSession)
         );
     }
 
@@ -180,6 +269,8 @@ export class VcdApiClient {
     }
 
     /**
+     * @deprecated Use {@link VcdApiClient#setCloudApiAuthentication}
+     *
      * Sets the authentication token to use for the VcdApiClient.
      *
      * After setting the token, the client will get the current session
@@ -190,6 +281,10 @@ export class VcdApiClient {
      * @returns the session associated with the authentication token
      */
     public setAuthentication(authentication: string): Observable<SessionType> {
+        if (this._isCloudApiLogin) {
+            return throwError('Only cloud api auth is allowed since it was already used');
+        }
+
         this.http.requestHeadersInterceptor.authentication = authentication;
         return this.http.get<SessionType>(`${this._baseUrl}/api/session`).pipe(
                 tap(session => {
@@ -207,6 +302,31 @@ export class VcdApiClient {
             );
     }
 
+    /**
+     * Sets the authentication token to use for the VcdApiClient.
+     *
+     * After setting the token, the client will get the current session
+     * information associated with the authenticated token.
+     *
+     * @param authentication the authentication string (to be used in either the 'Authorization'
+     *  or 'x-vcloud-authorization' header)
+     *
+     * @returns session observable associated with the authentication token
+     */
+    public setCloudApiAuthentication(authentication: string): Observable<Session> {
+        this.onBeforeCloudApiAuthentication();
+
+        return of(true)
+            .pipe(
+                // Set the authentication as part of the observable in order to ensure the caller has subscribed to the observable
+                tap(() => this.http.requestHeadersInterceptor.authentication = authentication),
+                switchMap(() => this.http.get<Session>(`${this._baseUrl}/cloudapi/1.0.0/sessions/current`, { observe: 'response' })),
+            )
+            .pipe(
+                this.onCloudApiAuthentication()
+            );
+    }
+
     public enableLogging(): VcdApiClient {
         this.http.loggingInterceptor.enabled = true;
 
@@ -214,6 +334,8 @@ export class VcdApiClient {
     }
 
     /**
+     * @deprecated Use {@link VcdApiClient#cloudApiLogin}
+     *
      * Creates an authenticated session for the specified credential data.
      *
      * @param username the name of the user to authenticate
@@ -222,6 +344,9 @@ export class VcdApiClient {
      * @returns an authenticated session for the given credentials
      */
     public login(username: string, tenant: string, password: string): Observable<SessionType> {
+        if (this._isCloudApiLogin) {
+            return throwError('Only cloud api auth is allowed since it was already used');
+        }
         const authString: string = btoa(`${username}@${tenant}:${password}`);
 
         return this.http.post<SessionType>(
@@ -240,6 +365,107 @@ export class VcdApiClient {
             map(response => response.body),
             tap(session => this._session.next(session))
         );
+    }
+
+    /**
+     * Creates an authenticated session for the specified credential data using cloud api endpoint.
+     *
+     * @param username the name of the user to authenticate
+     * @param tenant the organization the user belongs to
+     * @param password the password for the user
+     * @returns an authenticated session for the given credentials
+     */
+    public cloudApiLogin(username: string, tenant: string, password: string): Observable<Session> {
+        this.onBeforeCloudApiAuthentication();
+
+        const authString: string = btoa(`${username}@${tenant}:${password}`);
+        let url = `${this._baseUrl}/cloudapi/1.0.0/sessions`;
+        if (tenant.toLowerCase() === 'system') {
+            url += '/provider';
+        }
+        return this.http.post<Session>(
+            url,
+            null,
+            {
+                observe: 'response',
+                headers: new HttpHeaders({ [HTTP_HEADERS.Authorization]: `Basic ${authString}` })
+            }
+        ).pipe(
+            tap((response: HttpResponse<Session>) => {
+                // tslint:disable-next-line:max-line-length
+                const token = `${response.headers.get('x-vmware-vcloud-token-type')} ${response.headers.get('x-vmware-vcloud-access-token')}`;
+                this.http.requestHeadersInterceptor.authentication = token;
+            }),
+            this.onCloudApiAuthentication()
+        );
+    }
+
+    /**
+     * It is necessary to know if an explicit cloud api auth request was done.
+     * This function handles this by setting the corresponding flags, properties etc.
+     */
+    private onBeforeCloudApiAuthentication() {
+        // In case of an explicit cloud api auth request:
+        // Set the flag _isCloudApiLogin in order to know that explicit cloud api authentication is done
+        // This will help us skip code related to the old api, i.e. we should not allow explicit mix of both the api-s
+        this._isCloudApiLogin = true;
+        // In case of an explicit cloud api auth request:
+        // There is no need of _getCloudApiSession observable which is needed in the automatic login during the constructor initialization.
+        // The explicit cloud api auth request will retrieve the session.
+        this._getCloudApiSession = of(null);
+    }
+
+    /**
+     * Handle authentication.
+     * This includes getting HATEOAS links, setting the session, handling errors etc.
+     */
+    private onCloudApiAuthentication(): (source: Observable<HttpResponse<Session>>) => Observable<Session> {
+        return (source) => source.pipe(
+            tap((resp: HttpResponse<Session>) => {
+                // Get HATEOAS links
+                try {
+                    this.setCloudApiSessionLinks(parseHeaderHateoasLinks(resp.headers.get(HATEOAS_HEADER)));
+                } catch (e) {
+                    console.log('Error when parsing session HATEOAS links:', e);
+                }
+            }),
+            map(resp => resp.body),
+            tap((session: Session) => {
+                // Clear previous actAs
+                this.actAs(null);
+                // automatically set actAs for provider in tenant scope
+                if (session.org && session.org.name === 'System' && this.injector.get(SESSION_SCOPE) === 'tenant') {
+                    // Automatic actAs only works in versions >=9.5
+                    try {
+                        this.actAs({ id: this.injector.get(SESSION_ORG_ID) });
+                    } catch (e) {
+                        console.warn('No SESSION_ORG_ID set in container. Automatic actAs is disabled.');
+                    }
+                }
+            }),
+            tap((session: Session) => this._cloudApiSession.next(session)),
+            catchError((e) => {
+                this.onCloudApiAuthenticationError();
+                return throwError(e);
+            })
+        );
+    }
+
+    private onCloudApiAuthenticationError() {
+        // Clear the authentication so that any subsequent backend calls are not authenticated
+        this.http.requestHeadersInterceptor.authentication = '';
+        // _getCloudApiSession is in the center of any backend call, nullify it in order not to prevent those calls
+        // since it is easier to troubleshoot failing backend rather than no call
+        this._getCloudApiSession = of(null);
+        // Clear the links
+        this._cloudApiSessionLinks.next([]);
+        // Clear the session
+        this._cloudApiSession.next(null);
+    }
+
+    private setCloudApiSessionLinks(links: LinkType[]) {
+        this._cloudApiAccessibleLocations = null;
+        this._cloudApiSessionLinks.next(links || []);
     }
 
     public get<T>(endpoint: string): Observable<T> {
@@ -388,7 +614,7 @@ export class VcdApiClient {
     }
 
     /**
-     * Queries the vCloud Director API based on the specified Query.Builder instance.
+     * Queries the VMware Cloud Director API based on the specified Query.Builder instance.
      *
      * @param builder An definition of the query to construct (type, filter, page size, etc.)
      * @param multisite a flag indicating whether or not to fan the query out to all available sites
@@ -396,7 +622,7 @@ export class VcdApiClient {
      */
     public query<T>(builder: Query.Builder, multisite?: boolean): Observable<T>;
     /**
-     * Queries the vCloud Director API based on the specified Query.Builder instance.
+     * Queries the VMware Cloud Director API based on the specified Query.Builder instance.
      *
      * @param builder An definition of the query to construct (type, filter, page size, etc.)
      * @param multisite the set of site locations to include in the query fanout
@@ -409,7 +635,7 @@ export class VcdApiClient {
     }
 
     /**
-     * Queries the vCloud Director API for the first page of the provided result set.
+     * Queries the VMware Cloud Director API for the first page of the provided result set.
      *
      * @param result the result set to retrieve the first page of records for
      * @param multisite a flag indicating whether or not to fan the query out to all available sites
@@ -417,7 +643,7 @@ export class VcdApiClient {
      */
     public firstPage<T>(result: T, multisite?: boolean): Observable<T>;
     /**
-     * Queries the vCloud Director API for the first page of the provided result set.
+     * Queries the VMware Cloud Director API for the first page of the provided result set.
      *
      * @param result the result set to retrieve the first page of records for
      * @param multisite the set of site locations to include in the query fanout
@@ -439,7 +665,7 @@ export class VcdApiClient {
     }
 
     /**
-     * Queries the vCloud Director API for the previous page of the provided result set.
+     * Queries the VMware Cloud Director API for the previous page of the provided result set.
      *
      * @param result the result set to retrieve the previous page of records for
      * @param multisite a flag indicating whether or not to fan the query out to all available sites
@@ -447,7 +673,7 @@ export class VcdApiClient {
      */
     public previousPage<T>(result: T, multisite?: boolean): Observable<T>;
     /**
-     * Queries the vCloud Director API for the previous page of the provided result set.
+     * Queries the VMware Cloud Director API for the previous page of the provided result set.
      *
      * @param result the result set to retrieve the previous page of records for
      * @param multisite the set of site locations to include in the query fanout
@@ -469,7 +695,7 @@ export class VcdApiClient {
     }
 
     /**
-     * Queries the vCloud Director API for the next page of the provided result set.
+     * Queries the VMware Cloud Director API for the next page of the provided result set.
      *
      * @param result the result set to retrieve the next page of records for
      * @param multisite a flag indicating whether or not to fan the query out to all available sites
@@ -477,7 +703,7 @@ export class VcdApiClient {
      */
     public nextPage<T>(result: T, multisite?: boolean): Observable<T>;
     /**
-     * Queries the vCloud Director API for the next page of the provided result set.
+     * Queries the VMware Cloud Director API for the next page of the provided result set.
      *
      * @param result the result set to retrieve the next page of records for
      * @param multisite the set of site locations to include in the query fanout
@@ -499,7 +725,7 @@ export class VcdApiClient {
     }
 
     /**
-     * Queries the vCloud Director API for the last page of the provided result set.
+     * Queries the VMware Cloud Director API for the last page of the provided result set.
      *
      * @param result the result set to retrieve the last page of records for
      * @param multisite a flag indicating whether or not to fan the query out to all available sites
@@ -507,7 +733,7 @@ export class VcdApiClient {
      */
     public lastPage<T>(result: T, multisite?: boolean): Observable<T>;
     /**
-     * Queries the vCloud Director API for the last page of the provided result set.
+     * Queries the VMware Cloud Director API for the last page of the provided result set.
      *
      * @param result the result set to retrieve the last page of records for
      * @param multisite the set of site locations to include in the query fanout
@@ -563,27 +789,97 @@ export class VcdApiClient {
         return typeof multisite === 'boolean' ? (multisite ? 'global' : 'local') : multisite.map(site => site.locationId).join(',');
     }
 
+    /**
+     * @deprecated Use cloudApiSession
+     */
     public get session(): Observable<SessionType> {
         return this.validateRequestContext().pipe(
             concatMap(() => this._sessionObservable)
         );
     }
 
-    public get username(): Observable<string> {
-        return this.session.pipe(
-            map(session => session.user)
+    /**
+     * Get Session observable
+     */
+    public get cloudApiSession(): Observable<Session> {
+        return this.validateRequestContextCloudApiOnly().pipe(
+            concatMap(() => this._cloudApiSessionObservable)
         );
+    }
+
+    public get username(): Observable<string> {
+        return merge(
+                this.cloudApiSession.pipe(
+                    filter(() => this._isCloudApiLogin),
+                    map(session => session && session.user && session.user.name)
+                ),
+                this.session.pipe(
+                    filter(() => !this._isCloudApiLogin),
+                    map(session => session && session.user)
+                )
+            );
     }
 
     public get organization(): Observable<string> {
-        return this.session.pipe(
-            map(session => session.org)
+        return merge(
+            this.cloudApiSession.pipe(
+                filter(() => this._isCloudApiLogin),
+                map(session => session && session.org && session.org.name)
+            ),
+            this.session.pipe(
+                filter(() => !this._isCloudApiLogin),
+                map(session => session && session.org)
+            )
         );
     }
 
+    /**
+     * @deprecated Use cloudApiLocation
+     */
     public get location(): Observable<AuthorizedLocationType> {
         return this.session.pipe(
             map(session => session.authorizedLocations.location.find(location => location.locationId === session.locationId))
+        );
+    }
+
+    /**
+     * Gets the location corresponding to the current session
+     */
+    public get cloudApiLocation(): Observable<AccessibleLocation> {
+        return this.cloudApiSession.pipe(
+            switchMap(() => {
+                if (!this._cloudApiAccessibleLocations) {
+                    // Ensure caching for getting AccessibleLocations
+                    this._cloudApiAccessibleLocations = this._cloudApiSessionLinks
+                        .pipe(
+                            // Get the AccessibleLocations link
+                            map((links) => this.findLink({ link: links }, 'down', 'AccessibleLocations')),
+                            // Fetch AccessibleLocations from the backend
+                            switchMap((link: LinkType) => link ? this.http.get<AccessibleLocations>(link.href) : of(null)),
+                            // Get the array with all locations (what if there are many pages)
+                            map((accessibleLocations: AccessibleLocations) => accessibleLocations && accessibleLocations.values)
+                        )
+                        .pipe(
+                            publishReplay(1),
+                            refCount()
+                        );
+                }
+                return this._cloudApiAccessibleLocations;
+            }),
+
+            // Need to have the session in order to get its location
+            withLatestFrom(this.cloudApiSession),
+            // Find the location that corresponds to this session
+            map(([accessibleLocations, session]) => {
+                if (!accessibleLocations || !session) {
+                    return null;
+                }
+                const sessionLocation = session.location;
+                if (!sessionLocation) {
+                    return null;
+                }
+                return accessibleLocations.find(location => location.locationId === sessionLocation);
+            }),
         );
     }
 

--- a/packages/angular/src/openapi.ts
+++ b/packages/angular/src/openapi.ts
@@ -1,0 +1,84 @@
+/**
+ * Entity reference used to describe VCD entities
+ */
+export class EntityReference {
+    'name': string;
+    'id': string;
+}
+
+/**
+ * Session
+ */
+export class Session {
+    /**
+     * ID of session
+     */
+    'id': string;
+    /**
+     * User of this session
+     */
+    'user': EntityReference;
+    /**
+     * Organization user is logged into for this session
+     */
+    'org': EntityReference;
+    /**
+     * The accessible location this session is valid for
+     */
+    'location': string;
+    /**
+     * User's roles for this session
+     */
+    'roles': Array<string>;
+    /**
+     * References to user's roles
+     */
+    'roleRefs': Array<EntityReference>;
+    /**
+     * The session idle timeout in minutes
+     */
+    'sessionIdleTimeoutMinutes': number;
+}
+
+/**
+ * A list of locations accessible to this session.
+ */
+export interface AccessibleLocations {
+    /**
+     * How many results there are in total (i.e., considering all pages).
+     */
+    resultTotal?: number;
+
+    /**
+     * How many pages there are in total.
+     */
+    pageCount?: number;
+
+    /**
+     * The page that was fetched, 1-indexed.
+     */
+    page?: number;
+
+    /**
+     * Result count for page that was fetched.
+     */
+    pageSize?: number;
+
+    /**
+     * The current page of accessible locations.
+     */
+    values?: Array<AccessibleLocation>;
+
+}
+
+/**
+ * A location accessible to this session.
+ */
+export class AccessibleLocation {
+    'locationId': string;
+    'site': EntityReference;
+    'org': EntityReference;
+    'restApiEndpoint': string;
+    'uiEndpoint': string;
+    'apiVersion': string;
+}

--- a/packages/angular/tsconfig.spec.json
+++ b/packages/angular/tsconfig.spec.json
@@ -24,6 +24,7 @@
     "src/test.ts"
   ],
   "include": [
+    "**/*.spec.data.ts",
     "**/*.spec.ts",
     "**/*.d.ts"
   ]


### PR DESCRIPTION
# Description
This pull request contains 2 commits:

##    Fix RequestHeadersInterceptor
    User is not able to login since `RequestHeadersInterceptor` was always taking place
    replacing the `Authorization` with the old authentication value.
    The solution is not to set the `Authorization` if it was already set (the case with login workflow).    

##    Add cloud api authenticatication mechanism
    
    Up to now the VcdAPiClient was using only `/api/session` endpoint for
    the authentication and the corresponding API model.
    This endpoint is deprecated and the openapi should be used instead.
    This CLN introduces that.
    
#   Note
`@vcd/bindings` are not updated yet, so we have manually added the  `openapi` bindings
    
#    Testing done
    Using a plugin:
    0. Without doing any explicit backend call verify that the user can
    access `cloudApiXXX` properties as well as their api/session counterparts.
    
    1. Perform a `vcdApi.cloudApiLogin()` with a different user and verify
    that the session, username, organization, can be retrieved through the
    `cloudApiXXX` properties
    2. perform a failing `vcdApi.cloudApiLogin()` attempt and verify that the session is nullified
    3. get `cloudApiLocation` and verify they are retrieved from the backend just once
