### PR TITLE
Release of node-client

### DIFF
--- a/.github/workflows/development-workflow.yml
+++ b/.github/workflows/development-workflow.yml
@@ -75,37 +75,11 @@ jobs:
             **/lib
           key: ${{github.sha}}-artifacts
       - run: npm run build
-  publish-next:
+  publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [dependencies, build]
-    name: Publish @next
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-          registry-url: https://registry.npmjs.org/
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/node_modules
-          key: ${{github.sha}}-dependencies
-      - uses: actions/cache@v2
-        with:
-          path: |
-            **/dist
-            **/lib
-          key: ${{github.sha}}-artifacts
-      - run: npm run publish -- --dist-tag next
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-  publish-release:
-    if: ${{ github.event.action == 'released' }}
-    runs-on: ubuntu-latest
-    needs: [dependencies, build]
-    name: Publish @latest
+    name: Publish
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "lerna run build",
     "test": "lerna run test",
     "test-ci": "lerna run test-ci",
-    "publish": "lerna publish from-package --no-git-reset --no-private --yes --no-verify-access"
+    "publish": "lerna publish from-package --no-git-reset --no-private --yes --no-verify-access --pre-dist-tag next"
   },
   "name": "cloud-director-typescript-clients"
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/angular-client",
-  "version": "0.0.2-alpha.6",
+  "version": "0.0.2-alpha.7",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/node-client",
   "description": "VMware Cloud Director Client bindings for NodeJS",
-  "version": "0.0.5-alpha.6",
+  "version": "0.0.5",
   "author": "VMware",
   "license": "BSD-2",
   "dependencies": {


### PR DESCRIPTION
* Updated the github actions workflow to run `npm run publish` only on push to `main`
* Removed the prerelease version of the node-client -> should release to npmjs as @latest
* Bumped the angular-client version -> should release to npmjs as @latest

Signed-off-by: Milko Slavov <mslavov@vmware.com>