### PR TITLE
Pass the original authentication object for the legacy client

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/node-client",
   "description": "VMware Cloud Director Client bindings for NodeJS",
-  "version": "0.0.6-alpha.0",
+  "version": "0.0.6-alpha.1",
   "author": "VMware",
   "license": "BSD-2",
   "dependencies": {

--- a/packages/node/provenance.json
+++ b/packages/node/provenance.json
@@ -1,16 +1,16 @@
 {
   "id": "http://vmware.com/schemas/software_provenance-0.2.0.json",
-  "root": "0.0.6-alpha.0",
+  "root": "0.0.6-alpha.1",
   "all-components": {
     "name": "@vcd/node-client",
-    "version": "0.0.6-alpha.0",
+    "version": "0.0.6-alpha.1",
     "source_repositories": [
       {
         "content": "source",
         "host": "github.com",
         "protocol": "git",
         "paths": [
-          "/vmware/vcd-ext-sdk/tree/main/ev/Documents/Projects/Solutions/cloud-director-typescript-clients/packages/node"
+          "/vmware/vcd-ext-sdk/tree/main/r/work/cloud-director-typescript-clients/cloud-director-typescript-clients/packages/node"
         ],
         "branch": "main"
       }

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -146,13 +146,7 @@ export class CloudDirectorConfig {
             throw new Error("Connection not authorized, please login again to fix any auth errors.");
         }
 
-        const username = this.authentication.username;
-        const org = this.authentication.org;
-        const token = this.authentication.authorizationKey;
-
-        return new LegacyApiClient(this.basePath,
-            new CloudDirectorAuthentication(username, org, token),
-            false);
+        return new LegacyApiClient(this.basePath, this.authentication, false);
     }
 
     public saveConfig(alias: string, fileLocation?: string): void {


### PR DESCRIPTION
as it contains more data like 'actAs'

Signed-off-by: Vilian Venkov <vvenkov@vmware.com>