### PR TITLE
Extend the transfer client implementation

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/node-client",
   "description": "VMware Cloud Director Client bindings for NodeJS",
-  "version": "0.0.6-alpha.1",
+  "version": "0.0.6-alpha.2",
   "author": "VMware",
   "license": "BSD-2",
   "dependencies": {

--- a/packages/node/provenance.json
+++ b/packages/node/provenance.json
@@ -1,9 +1,9 @@
 {
   "id": "http://vmware.com/schemas/software_provenance-0.2.0.json",
-  "root": "0.0.6-alpha.1",
+  "root": "0.0.6-alpha.2",
   "all-components": {
     "name": "@vcd/node-client",
-    "version": "0.0.6-alpha.1",
+    "version": "0.0.6-alpha.2",
     "source_repositories": [
       {
         "content": "source",

--- a/packages/node/src/auth.ts
+++ b/packages/node/src/auth.ts
@@ -22,6 +22,10 @@ export abstract class CloudDirectorDefaultHeaders implements api.Authentication 
         this.actAsId = id;
     }
 
+    public getActAsId() {
+        return this.actAsId;
+    }
+
     abstract clone(): CloudDirectorDefaultHeaders
 }
 

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -111,11 +111,11 @@ export class CloudDirectorConfig {
         return apiClient;
     }
 
-    public makeTransferClient(url: string) {
+    public makeTransferClient() {
         if (!this.connectionAuth.authorized) {
             throw new Error("Connection not authorized, please login again and accept and auth errors.");
         }
-        return new TransferClient(url, this.authentication.authorizationKey, false);
+        return new TransferClient(this.authentication, false);
     }
 
     public makeMQTTClient(onConnect: (client: mqtt.MqttClient) => void) {

--- a/packages/node/src/legacy.api.client.ts
+++ b/packages/node/src/legacy.api.client.ts
@@ -36,6 +36,7 @@ export class LegacyApiClient {
         return new Promise<T>((resolve, reject) => {
             const clientRequest = https.request(requestOptions, res => {
                 if (res.statusCode < 200 || res.statusCode > 299) {
+                    res.on('data', e => console.error(e));
                     reject('Something went wrong. Status code: ' + res.statusCode);
                 }
 

--- a/packages/node/src/transfer.spec.ts
+++ b/packages/node/src/transfer.spec.ts
@@ -1,14 +1,14 @@
-import { } from 'jasmine';
 import * as fs from 'fs';
 import { Readable }  from "stream"
 import * as nock from 'nock';
 import { TransferClient } from './transfer';
+import {CloudDirectorAuthentication} from './auth';
 
 describe('Transfer Client tests', () => {
     it('Uploads a file', async () => {
         const path = "/test/file/path";
         const contentType = "application/zip";
-        var readable = new Readable() as fs.ReadStream
+        let readable = new Readable() as fs.ReadStream
         readable.path = path
         readable.push('beep')    // the string you want
         readable.push(null)
@@ -21,8 +21,9 @@ describe('Transfer Client tests', () => {
         })
             .put('/transfer/url')
             .reply(200)
-        const client = new TransferClient("https://www.example.com/transfer/url", "testKey")
-        await client.upload(path, contentType)
+        const auth = new CloudDirectorAuthentication('username', 'org', 'testKey');
+        const client = new TransferClient(auth)
+        await client.upload("https://www.example.com/transfer/url", path, contentType)
         expect(scope.isDone()).toBeTrue()
     });
 })


### PR DESCRIPTION
Change transfer client to accept url as method param - not constructor.
Add act as to the transfer client.
Print the response on error requests, not only the status code.

Signed-off-by: Vilian Venkov <vvenkov@vmware.com>