### PR TITLE
Updating API candidate versions list

### DIFF
--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,5 +1,12 @@
 # [Unreleased]
--
+
+# 0.0.2-alpha.8 (2022-07-22)
+Problem:
+- API versions '32.0', '31.0', '30.0' are deleted for VCD 10.4
+- API versions '37.0', '36.3', '36.2', '36.1', '36.0' are supported in 10.4
+
+Fix:
+Remove deleted and add missing supported API versions in the vcd API client.
 
 # 0.0.2-alpha.6 (2021-06-24)
 - Removed unnecessary parseHeaderHateoasLinks for etag headers in RequestHeadersInterceptor

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/angular-client",
-  "version": "0.0.2-alpha.7",
+  "version": "0.0.2-alpha.8",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2",

--- a/packages/angular/src/client/vcd.api.client.ts
+++ b/packages/angular/src/client/vcd.api.client.ts
@@ -119,7 +119,7 @@ export enum LinkRelType {
 @Injectable()
 export class VcdApiClient {
     /** The default list of API versions (from most preferred to least) that the SDK supports. */
-    static readonly CANDIDATE_VERSIONS: string[] = ['35.2', '35.0', '34.0', '33.0', '32.0', '31.0', '30.0'];
+    static readonly CANDIDATE_VERSIONS: string[] = ['37.0', '36.3', '36.2', '36.1', '36.0', '35.2', '35.0', '34.0', '33.0'];
 
     set baseUrl(_baseUrl: string) {
         this._baseUrl = _baseUrl;


### PR DESCRIPTION
- API versions '32.0', '31.0', '30.0' are deleted for VCD 10.4
- API versions '37.0', '36.3', '36.2', '36.1', '36.0' are supported in 10.4

Fix:
Remove deleted and add missing supported API versions in the vcd API client.

Signed-off-by: Lyubomir Stoychev <stoychevl@vmware.com>