### PR TITLE
Add ability VcdApiClient to work with absolute URL and specify headers for CRUD requests

### DIFF
--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [Unreleased]
+
+# 0.0.2-alpha.9 (2022-08-01)
 - VcdApiClient can work with absolute URLs
 - VcdApiClient CRUD operations accept custom request HEADERS
 

--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [Unreleased]
+- VcdApiClient can work with absolute URLs
+- VcdApiClient CRUD operations accept custom request HEADERS
 
 # 0.0.2-alpha.8 (2022-07-22)
 Problem:

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/angular-client",
-  "version": "0.0.2-alpha.8",
+  "version": "0.0.2-alpha.9",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2",


### PR DESCRIPTION
Till now the VcdApiClient was always prepending the baseURL as defined in the host
application (VCD). But there are cases when the URL is already an absolute one.
This CLN allows VcdApiClient to work with absolute URL.

While there, all the CRUD operations are enabled to get custom headers

Testing done: Use customize-portal plugin that was working with absolute URL and therefore
needed to use angular http client directly. With this CLN the plugin is simplified
and uses the VcdApiClient directly